### PR TITLE
Add methods which set properties about border in SearchBar

### DIFF
--- a/Classes/DkNappAppearanceModule.m
+++ b/Classes/DkNappAppearanceModule.m
@@ -11,6 +11,32 @@
 #import "TiHost.h"
 #import "TiUtils.h"
 
+// http://stackoverflow.com/questions/25754006/how-to-change-the-uisearchbar-in-ios-7
+@interface UITextField (attr)
+- (void)setLayerCornerRadius:(CGFloat)cornerRadius;
+- (void)setLayerBorderColor:(UIColor *)color;
+- (void)setLayerBorderWidth:(CGFloat)width;
+@end
+
+@implementation UITextField (attr)
+
+- (void)setLayerCornerRadius:(CGFloat)cornerRadius
+{
+    self.layer.cornerRadius = cornerRadius;
+}
+
+-(void)setLayerBorderColor:(UIColor *)color
+{
+    self.layer.borderColor = color.CGColor;
+}
+
+-(void)setLayerBorderWidth:(CGFloat)width
+{
+    self.layer.borderWidth = width;
+}
+
+@end
+
 @implementation DkNappAppearanceModule
 
 #pragma mark Internal
@@ -534,6 +560,19 @@
     if([[scopeBarAttributes allKeys] count] > 0){
         [[UISearchBar appearance] setScopeBarButtonTitleTextAttributes:scopeBarAttributes forState:UIControlStateNormal];
     }
+    
+    if([args objectForKey:@"searchFieldBorderColor"] != nil) {
+        [[UITextField appearanceWhenContainedIn:[UISearchBar class], nil] setLayerBorderColor:[[TiUtils colorValue:@"searchFieldBorderColor" properties:args] _color]];
+    }
+    
+    if([args objectForKey:@"searchFieldBorderWidth"] != nil) {
+        [[UITextField appearanceWhenContainedIn:[UISearchBar class], nil] setLayerBorderWidth:[TiUtils floatValue:@"searchFieldBorderWidth" properties:args]];
+    }
+    
+    if([args objectForKey:@"searchFieldBorderRadius"] != nil) {
+        [[UITextField appearanceWhenContainedIn:[UISearchBar class], nil] setLayerCornerRadius:[TiUtils floatValue:@"searchFieldBorderRadius" properties:args]];
+    }
+    
     
     [self notifyOfStyleChange:@"searchBar"];
 }

--- a/README.md
+++ b/README.md
@@ -145,6 +145,9 @@ NappAppearance.setGlobalStyling({
 		//search field
 		searchFieldBackgroundImage:"/images/image.png",
 		searchFieldHighlightedBackgroundImage:"/images/image.png",
+		searchFieldBorderWidth: "1dp",
+		searchFieldBorderColor: "#ff0000",
+		searchFieldBorderRadius: "4dp",
 		
 		//cancel button
 		cancelTitlePositionOffset:{x:0, y:3},


### PR DESCRIPTION
Today, I added following methods:
- searchFieldBorderWidth
- searchFieldBorderColor
- searchFieldBorderRadius

This is example that  set to red border color for UITextiField in UISearchBar.

```
var NappAppearance = require('dk.napp.appearance');
NappAppearance.setGlobalStyling({
    searchBar:{
        searchFieldBorderWidth: "1dp",
        searchFieldBorderColor: "#ff0000",
        searchFieldBorderRadius: "4dp",
    }
})
```

![](https://gyazo.com/e9380ea8f3bd9171f6a0a80251cb537c.png)
